### PR TITLE
Wrap marker setIcon execute in try/catch to avoid crash in host app

### DIFF
--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -759,34 +759,43 @@ public class PluginMarker extends MyPlugin {
             callback.onPostExecute(marker);
             return;
           }
-          BitmapDescriptor bitmapDescriptor = BitmapDescriptorFactory.fromBitmap(image);
-          marker.setIcon(bitmapDescriptor);
           
-          // Save the information for the anchor property
-          Bundle imageSize = new Bundle();
-          imageSize.putInt("width", image.getWidth());
-          imageSize.putInt("height", image.getHeight());
-          PluginMarker.this.objects.put("imageSize", imageSize);
-          
+          try {
+              //TODO: check image is valid?
+              BitmapDescriptor bitmapDescriptor = BitmapDescriptorFactory.fromBitmap(image);
+              marker.setIcon(bitmapDescriptor);
+              
+              // Save the information for the anchor property
+              Bundle imageSize = new Bundle();
+              imageSize.putInt("width", image.getWidth());
+              imageSize.putInt("height", image.getHeight());
+              PluginMarker.this.objects.put("imageSize", imageSize);
+              
+    
+              // The `anchor` of the `icon` property
+              if (iconProperty.containsKey("anchor") == true) {
+                double[] anchor = iconProperty.getDoubleArray("anchor");
+                if (anchor.length == 2) {
+                  _setIconAnchor(marker, anchor[0], anchor[1], imageSize.getInt("width"), imageSize.getInt("height"));
+                }
+              }
+              
+    
+              // The `anchor` property for the infoWindow
+              if (iconProperty.containsKey("infoWindowAnchor") == true) {
+                double[] anchor = iconProperty.getDoubleArray("infoWindowAnchor");
+                if (anchor.length == 2) {
+                  _setInfoWindowAnchor(marker, anchor[0], anchor[1], imageSize.getInt("width"), imageSize.getInt("height"));
+                }
+              }
+    
+              callback.onPostExecute(marker);
+            
+              } catch (java.lang.IllegalArgumentException e) {
+                        Log.e("GoogleMapsPlugin","PluginMarker: Warning - marker method called when marker has been disposed, wait for addMarker callback before calling more methods on the marker (setIcon etc).");
+                        //e.printStackTrace();
 
-          // The `anchor` of the `icon` property
-          if (iconProperty.containsKey("anchor") == true) {
-            double[] anchor = iconProperty.getDoubleArray("anchor");
-            if (anchor.length == 2) {
-              _setIconAnchor(marker, anchor[0], anchor[1], imageSize.getInt("width"), imageSize.getInt("height"));
-            }
-          }
-          
-
-          // The `anchor` property for the infoWindow
-          if (iconProperty.containsKey("infoWindowAnchor") == true) {
-            double[] anchor = iconProperty.getDoubleArray("infoWindowAnchor");
-            if (anchor.length == 2) {
-              _setInfoWindowAnchor(marker, anchor[0], anchor[1], imageSize.getInt("width"), imageSize.getInt("height"));
-            }
-          }
-
-          callback.onPostExecute(marker);
+             }
         }
       };
       task.execute();


### PR DESCRIPTION
Markers may be invalidated and bitmaps disposed after the initial marker has been created, this can result in a fatal IllegalArgumentException. The exception can cause the host cordova app to crash therefore catching it (and warning via Log) is necessary.