### PR TITLE
fix TileOverlay remove bug & tileProvider functions still work

### DIFF
--- a/src/android/plugin/google/maps/PluginTileOverlay.java
+++ b/src/android/plugin/google/maps/PluginTileOverlay.java
@@ -43,7 +43,7 @@ public class PluginTileOverlay extends MyPlugin implements MyPluginInterface {
     String id = "tile_" + tileOverlay.getId();
 
     this.objects.put(id, tileOverlay);
-    this.objects.put("tileProvider_" + id.replace("tile_", "tileProvider_"), tileProvider);
+    this.objects.put(id.replace("tile_", "tileProvider_"), tileProvider);
 
     JSONObject result = new JSONObject();
     result.put("hashCode", tileOverlay.hashCode());

--- a/src/android/plugin/google/maps/PluginTileOverlay.java
+++ b/src/android/plugin/google/maps/PluginTileOverlay.java
@@ -42,8 +42,8 @@ public class PluginTileOverlay extends MyPlugin implements MyPluginInterface {
     TileOverlay tileOverlay = this.map.addTileOverlay(options);
     String id = "tile_" + tileOverlay.getId();
 
-    this.objects.put("tileProvider_" + id, tileProvider);
-    
+    this.objects.put(id, tileOverlay);
+    this.objects.put("tileProvider_" + id.replace("tile_", "tileProvider_"), tileProvider);
 
     JSONObject result = new JSONObject();
     result.put("hashCode", tileOverlay.hashCode());


### PR DESCRIPTION
tileOverlay needed to be added to the hashmap, as it is what is removed on line 86.
Tested on my phone with adb Log messages to confirm.
fixes issue #526

Also tested that setOpacity() & clearTileCache() functions work.