### PR TITLE
Remove deprecated plugin from plugin.xml; use <framework> tag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
             </feature>
         </config-file>
 
-        <dependency id="com.google.playservices" url="https://github.com/wf9a5m75/google-play-services#v23" />
+        <framework src="com.google.android.gms:play-services-location:7.3.0" />
     
         <!-- plugin src files -->
         <source-file src="src/android/plugin/google/maps/AsyncLicenseInfo.java" target-dir="src/plugin/google/maps" />


### PR DESCRIPTION
Google Play Services dependency was incorrectly included in Android build. It conflicted with cordova-background-geolocation and caused a build error:

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':processArmv7DebugResources'.
> Error: more than one library with package name 'com.google.android.gms'
  You can temporarily disable this error with android.enforceUniquePackageName=false
  However, this is temporary and will be enforced in 1.0

The pull request comes from discussion on cordova-background-geolocation. Credit to christocracy and lakano.