### PR TITLE
bumbed version 1.3.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="plugin.google.maps" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="plugin.google.maps" version="1.3.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>phonegap-googlemaps-plugin</name>
     <js-module name="phonegap-googlemaps-plugin" src="www/googlemaps-cdv-plugin.js">
         <clobbers target="plugin.google.maps" />
@@ -17,9 +17,7 @@
     <engines>
       <engine name="cordova" version=">=3.5.0" />
     </engines>
-    
-    <dependency id="plugin.http.request" />
-    
+        
     <!-- android -->
     <platform name="android">
         <preference name="API_KEY_FOR_ANDROID" />

--- a/src/android/plugin/google/maps/GoogleMaps.java
+++ b/src/android/plugin/google/maps/GoogleMaps.java
@@ -17,7 +17,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import plugin.http.request.HttpRequest;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -151,6 +150,8 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
   
           try {
             
+            /*
+              
             JSONArray params = new JSONArray();
             params.put("get");
             params.put("http://plugins.cordova.io/api/plugin.google.maps");
@@ -172,6 +173,7 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
                 }
               }
             });
+            */
           } catch (Exception e) {}
         }
       });

--- a/src/ios/GoogleMaps/External.m
+++ b/src/ios/GoogleMaps/External.m
@@ -45,7 +45,7 @@
       [NSString stringWithFormat: @"comgooglemaps-x-callback://?%@", [params componentsJoinedByString: @"&"], nil];
   } else {
     directionsRequest =
-      [NSString stringWithFormat: @"http://maps.apple.com/?saddr=%@&daddr=%@",
+      [NSString stringWithFormat: @"https://maps.apple.com/?saddr=%@&daddr=%@",
         from, to, nil];
   }
   NSURL *directionsURL = [NSURL URLWithString:directionsRequest];

--- a/src/ios/GoogleMaps/GroundOverlay.m
+++ b/src/ios/GoogleMaps/GroundOverlay.m
@@ -129,9 +129,8 @@
     return;
   }
 
-  
-  range = [urlStr rangeOfString:@"http://"];
-  if (range.location == NSNotFound) {
+  NSURL *isUrl = [NSURL URLWithString:urlStr];
+  if (!isUrl || !isUrl.scheme || isUrl.host) {
     layer.icon = [UIImage imageNamed:urlStr];
     [self.mapCtrl.overlayManager setObject:layer.icon forKey: id];
     completionHandler(nil);

--- a/src/ios/GoogleMaps/KmlOverlay.m
+++ b/src/ios/GoogleMaps/KmlOverlay.m
@@ -68,8 +68,8 @@
   }
 
   
-  range = [urlStr rangeOfString:@"http://"];
-  if (range.location == NSNotFound) {
+   NSURL *isUrl = [NSURL URLWithString:urlStr];
+   if (!isUrl || !isUrl.scheme || !isUrl.host) {
     tbxml = [tbxml initWithXMLFile:urlStr error:&error];
   } else {
     NSURLRequest *req = [NSURLRequest requestWithURL:[NSURL URLWithString:urlStr]];


### PR DESCRIPTION
As the cordova repo is offline soon, we really don’t need a version  check, as it just slows down start-up performance when app is in debug.

fixed http:// call for External on iOS, added better URL-Detection for KML and GroundOverlay (support for all valid NSURL Types on iOS)