### PR TITLE
Remove use of 'const' in js to allow plugin to be 'browserify'ed

### DIFF
--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -2474,7 +2474,7 @@ document.addEventListener("deviceready", function() {
   plugin.google.maps.Map.isAvailable();
 });
 
-const HTML_COLORS = {
+var HTML_COLORS = {
   "alideblue" : "#f0f8ff",
   "antiquewhite" : "#faebd7",
   "aqua" : "#00ffff",


### PR DESCRIPTION
Being part of ES6 and not supported by all browser, this fails to parse with some libraries; in the case of cordova's browserify process (cordova --browserify) an error is generated:

SyntaxError: Unexpected token (2476:6) (while aliasify was processing <project>/plugins/plugin.google.maps/www/googlemaps-cdv-plugin.js) while parsing file: <project>/plugins/plugin.google.maps/www/googlemaps-cdv-plugin.js

This error comes from the acorn library (dependency of the aliasify module): node_modules/cordova/node_modules/cordova-lib/node_modules/aliasify/node_modules/browserify-transform-tools/node_modules/falafel/node_modules/acorn